### PR TITLE
Configure custom domain franciscormendes.com

### DIFF
--- a/_config.icarus.yml
+++ b/_config.icarus.yml
@@ -48,7 +48,7 @@ head:
         url: 
         # Page cover (og:image) (optional)
         # You should leave this blank for most of the time
-        image: https://franciscormendes.github.io/gallery/DSC00878.jpg
+        image: https://franciscormendes.com/gallery/DSC00878.jpg
         # Site name (og:site_name) (optional)
         # You should leave this blank for most of the time
         site_name: Francisco Mendes
@@ -90,10 +90,10 @@ head:
         publisher: Francisco Mendes
         # Page publisher logo (optional)
         # You should leave this blank for most of the time
-        publisher_logo: https://franciscormendes.github.io/gallery/favicon-32x32.png
+        publisher_logo: https://franciscormendes.com/gallery/favicon-32x32.png
         # Page images (optional)
         # You should leave this blank for most of the time
-        image: https://franciscormendes.github.io/gallery/DSC00878.jpg
+        image: https://franciscormendes.com/gallery/DSC00878.jpg
     # Additional HTML meta tags in an array
     meta:
         # Meta tag specified in <attribute>=<value> style

--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ keywords: machine learning, statistics, signal processing, deep learning
 author: Francisco Romaldo Fernandes Mendes
 language: en
 timezone: ''
-url: https://franciscormendes.github.io
+url: https://franciscormendes.com
 permalink: ':year/:month/:day/:title/'
 permalink_defaults: null
 pretty_urls:

--- a/source/CNAME
+++ b/source/CNAME
@@ -1,0 +1,1 @@
+franciscormendes.com

--- a/source/robots.txt
+++ b/source/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://franciscormendes.github.io/sitemap.xml
+Sitemap: https://franciscormendes.com/sitemap.xml


### PR DESCRIPTION
## Summary

- `source/CNAME`: new file containing `franciscormendes.com` so GitHub Pages preserves the custom domain on every deploy
- `_config.yml`: update `url` to `https://franciscormendes.com`
- `_config.icarus.yml`: update all absolute `og:image` and `publisher_logo` URLs
- `source/robots.txt`: update `Sitemap` pointer to new domain

## DNS setup (required before merging)

Add these records at your registrar:

| Type | Name | Value |
|------|------|-------|
| A | `@` | `185.199.108.153` |
| A | `@` | `185.199.109.153` |
| A | `@` | `185.199.110.153` |
| A | `@` | `185.199.111.153` |
| CNAME | `www` | `franciscormendes.github.io` |

Then: GitHub repo → Settings → Pages → Custom domain → `franciscormendes.com` → Save → enable "Enforce HTTPS".

## Test plan

- [x] DNS propagated (check at dnschecker.org for the four A records)
- [x] `franciscormendes.com` serves the site over HTTPS
- [x] `franciscormendes.github.io` 301-redirects to `franciscormendes.com`
- [x] `public/CNAME` contains `franciscormendes.com` after `hexo generate`
- [x] `og:image` in page source points to `franciscormendes.com`
