### PR TITLE
Fix image caption spacing across the blog

### DIFF
--- a/source/css/custom.css
+++ b/source/css/custom.css
@@ -167,6 +167,44 @@ article.article .content img:hover {
   filter: none;
 }
 
+/* ---------- Image captions ---------- */
+article.article .content figcaption {
+  margin-top: 0.65rem;
+  margin-bottom: 1.25rem;
+  font-size: 0.85rem;
+  color: #6b7280;
+  font-style: italic;
+  line-height: 1.5;
+}
+
+article.article .content div[align="center"] figcaption,
+article.article .content div[style*="text-align:center"] figcaption,
+article.article .content div[style*="text-align: center"] figcaption {
+  text-align: center;
+}
+
+html.dark article.article .content figcaption {
+  color: #9ca3af;
+}
+
+/* p > em used as captions inside centered image wrappers */
+article.article .content div[align="center"] p > em,
+article.article .content div[style*="text-align:center"] p > em,
+article.article .content div[style*="text-align: center"] p > em {
+  display: block;
+  margin-top: 0.65rem;
+  margin-bottom: 1.25rem;
+  font-size: 0.85rem;
+  color: #6b7280;
+  line-height: 1.5;
+}
+
+html.dark article.article .content div[align="center"] p > em,
+html.dark article.article .content div[style*="text-align:center"] p > em,
+html.dark article.article .content div[style*="text-align: center"] p > em {
+  color: #9ca3af;
+}
+
 /* ---------- Article content typography ---------- */
 article.article .content {
   font-size: 1.05rem;


### PR DESCRIPTION
## Summary
- Adds `margin-top` and `margin-bottom` to `figcaption` elements to visually separate captions from images
- Also targets the `p > em` pattern used as captions inside centered image wrappers
- Applies muted color (`#6b7280`) and italic style to captions for visual hierarchy
- Includes dark mode variants for both patterns

## Test plan
- [ ] Visit a post using `<figcaption>` (e.g. hot-cold-gcns-2) and confirm caption has clear spacing from image
- [ ] Visit acoustic-sensor-fusion post and confirm `<p><em>` captions have spacing
- [ ] Check dark mode renders caption color correctly